### PR TITLE
URLのパラメタから引数を付与

### DIFF
--- a/db_app_src/server.rb
+++ b/db_app_src/server.rb
@@ -6,8 +6,11 @@ set :bind, '0.0.0.0'
 
 app = App.new
 
+# e.g.) /7974/2021-09-09T14:59:30
 get '/:code/:datetime' do
-  app.exec(7974, '2021-09-09 14:59:30').to_json
+  stock_code = params['code']
+  datetime = params['datetime']
+  app.exec(stock_code, datetime).to_json
 end
 
 get '/exit' do


### PR DESCRIPTION
## 変更点

- ✨  `curl localhost:4567/:code/:datetime` の形式で任意の証券コード、日時を指定できるようにする


## 動作確認

```
$ curl localhost:4567/7974/2021-09-09T14:58:31
{"datetime":"2021-09-09 14:58:30","volume":"100","price":"xxx10"}
```