### PR TITLE
:sparkles: Add spliting JPX CSV script

### DIFF
--- a/db_init_src/splitter.rb
+++ b/db_init_src/splitter.rb
@@ -1,0 +1,40 @@
+# JPXの「現物情報 歩み値（ティック）」を銘柄コード別にバラすスクリプト。
+# http://db-ec.jpx.co.jp/category/C220/C22001202111.html
+# Usage: ruby splitter.rb
+
+require 'fileutils'
+
+input_file_path = 'stock_tick_202111.csv'
+output_parent_dir_path = './stock_ticks/202111'
+FileUtils.mkdir_p(output_parent_dir_path)
+
+def output_file_path(stock_code, output_parent_dir_path)
+  "#{output_parent_dir_path}/#{stock_code}.csv"
+end
+
+def get_stock_code(row)
+  first_index_of_stock_code = 13
+  stock_code_size = 4
+  row[first_index_of_stock_code..first_index_of_stock_code + stock_code_size - 1]
+end
+
+current_stock_code = nil
+file_pointer = nil
+headers = nil
+puts 'START'
+puts "input_file_path: #{input_file_path}"
+File.foreach(input_file_path).with_index do |row, i|
+  headers = row and next if i == 0
+  stock_code = get_stock_code(row)
+  if stock_code != current_stock_code
+    puts "[#{current_stock_code = stock_code}]"
+    file_pointer&.close
+    output_file_path = output_file_path(stock_code, output_parent_dir_path)
+    file_pointer = File.open(output_file_path, 'w')
+    file_pointer.puts headers
+  end
+  file_pointer.puts row
+  puts(sprintf("[#{stock_code}] Lines: %9d", i)) if i % 10000 == 0
+end
+file_pointer.close
+puts 'END'


### PR DESCRIPTION
## 変更点


- ✨ JPXの「現物情報 歩み値（ティック）」を銘柄コード別にバラすスクリプトを追加
  - CSVは http://db-ec.jpx.co.jp/category/C220/C22001202111.html でDL

## 使い方

`ruby splitter.rb` を実行すると、 `./stock_tick_202111.csv` を読み込んで、 `./stock_ticks/202111` 以下に `1234.csv` のフォーマットで分割したCSVを作成する。

```
$ ruby splitter.rb

...
[9984] Lines:  47340000
[9984] Lines:  47350000
[9984] Lines:  47360000
[9984] Lines:  47370000
[9984] Lines:  47380000
[9984] Lines:  47390000
```


